### PR TITLE
Avoid polling if Identity Manager is not available

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+indent_style = tab
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false


### PR DESCRIPTION
An instance of ZeroClientProvider by default polling RPC node with `eth_getBlockByNumber` method according to [zero.js](https://github.com/MetaMask/provider-engine/blob/97dcb09469866276843ff19ef7223a1f1e567b04/zero.js#L77) and [provider-engine](https://github.com/MetaMask/provider-engine/blob/97dcb09469866276843ff19ef7223a1f1e567b04/index.js#L55). This makes a set of wasteful requests when Identity Manager is not available.